### PR TITLE
Fix package installation instruction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ This is where your description should go. Take a look at [contributing.md](contr
 Via Composer
 
 ``` bash
-$ composer require mahmud/webdriver
+$ composer require mahmudkuet11/webdriver
 ```
 
 ## Usage


### PR DESCRIPTION
In packagist the package is registered as mahmudkuet11/webdriver. So current installation instruction is wrong.